### PR TITLE
Add dist folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 tests/coverage
 tests/js/testBundle.js
+dist


### PR DESCRIPTION
The built files are already being tracked, so this change will not
remove anything.  The change is beneficial for those contributing to not
see changes in the dist folder in their `git status`.  This will make
it harder to accidentally commit these files.

The dist folder should be generated at every version bump so that the changes
can be tagged.  The command to add the distribution files is:

```
git add -f dist
```

Closes #1 
